### PR TITLE
Fix uses of sourcesContent

### DIFF
--- a/src/util/collectSourceFiles.ts
+++ b/src/util/collectSourceFiles.ts
@@ -6,7 +6,7 @@ export function collectSourceFiles(sourceMap: SourceMap, originalFolderPath: str
   const filesMap = new Map<string, TestingFile>();
 
   sourceMap.sources.forEach((file: string, index: number) => {
-    filesMap.set(file, TestingFile.forTextFile(path.join(originalFolderPath, file), sourceMap.sourcesContent[index]))
+    filesMap.set(file, TestingFile.forTextFile(path.join(originalFolderPath, file), sourceMap.sourcesContent ? sourceMap.sourcesContent[index] : null))
   });
 
   return filesMap;

--- a/src/validators/SourceMapFormatValidator.ts
+++ b/src/validators/SourceMapFormatValidator.ts
@@ -22,9 +22,9 @@ export class SourceMapFormatValidator extends Validator {
       errors.push(new Error('Source map "mappings" field is missing.'));
     }
 
-    if ('sourcesContent' in sourceMap && !Array.isArray(sourceMap.sourcesContent)) {
-      errors.push(new Error('Source map "sources" field is invalid.'));
-    } else {
+    if ('sourcesContent' in sourceMap) {
+      if (!Array.isArray(sourceMap.sourcesContent))
+        errors.push(new Error('Source map "sources" field is invalid.'));
       sourceMap.sourcesContent.forEach((x: unknown, i: number) => {
         if (x !== null && typeof x !== "string") errors.push(new Error(`There is a source content with an invalid format on the index ${i}. Each content should be defined as a strings or null`))
       })


### PR DESCRIPTION
The code assumed the key was present, and failed to validate a source map that only had sources with separate files.