### PR TITLE
Adds support for index map validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/parser": "^7.23.3",
         "@babel/traverse": "^7.23.3",
-        "source-map": "^0.7.4",
+        "source-map": "^0.8.0-beta.0",
         "tc39-proposal-scope-mapping": "^0.1.1",
         "vlq": "^2.0.4",
         "yargs": "^17.7.2"
@@ -807,10 +807,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -821,9 +834,12 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
       "engines": {
         "node": ">= 8"
       }
@@ -879,6 +895,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/tsm": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tsm/-/tsm-2.3.0.tgz",
@@ -917,6 +941,21 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
       "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/parser": "^7.23.3",
     "@babel/traverse": "^7.23.3",
     "tc39-proposal-scope-mapping": "^0.1.1",
-    "source-map": "^0.7.4",
+    "source-map": "^0.8.0-beta.0",
     "vlq": "^2.0.4",
     "yargs": "^17.7.2"
   },

--- a/src/validators/SourceFilesValidator.ts
+++ b/src/validators/SourceFilesValidator.ts
@@ -9,12 +9,22 @@ export class SourceFilesValidator extends Validator {
     const errors: Error[] = [];
     const { sources, sourcesContent = [] } = context.sourceMap
 
-    sources.forEach((sourceFileName: string, index: number) => {
-      const fullPath = path.join(context.originalFolderPath, sourceFileName);
-      if (!fs.existsSync(fullPath) && sourcesContent[index] == undefined) {
-        errors.push(new Error(`Source file not found: ${sourceFileName}`));
-      }
-    });
+    function check(sources : any) {
+      sources.forEach((sourceFileName: string, index: number) => {
+        const fullPath = path.join(context.originalFolderPath, sourceFileName);
+        if (!fs.existsSync(fullPath) && sourcesContent[index] == undefined) {
+          errors.push(new Error(`Source file not found: ${sourceFileName}`));
+        }
+      });
+    };
+
+    if ("sections" in context.sourceMap) {
+      context.sourceMap.sections.forEach((section : any) => {
+        check(section.map.sources);
+      });
+    } else {
+      check(sources);
+    }
 
     return ValidationResult.from(errors)
   }

--- a/src/validators/SourceMapFormatValidator.ts
+++ b/src/validators/SourceMapFormatValidator.ts
@@ -10,26 +10,36 @@ export class SourceMapFormatValidator extends Validator {
       errors.push(new Error("Source map version is not 3."));
     }
 
-    if (!sourceMap.sources || !Array.isArray(sourceMap.sources)) {
-      errors.push(new Error('Source map "sources" field is invalid or missing.'));
+    if ("sections" in sourceMap) {
+      if ("mappings" in sourceMap) {
+        errors.push(new Error('Source map cannot have both "mappings" and "sections" fields.'));
+      }
+
+      if (typeof sourceMap.sections !== "object") {
+        errors.push(new Error('Source map "sections" field is not an object.'));
+      }
     } else {
-      sourceMap.sources.forEach((x: unknown, i: number) => {
-        if (typeof x !== "string") errors.push(new Error(`There is a source with an invalid format on the index ${i}. Each source should be defined as a string`))
-      })
-    }
+      if (!sourceMap.sources || !Array.isArray(sourceMap.sources)) {
+        errors.push(new Error('Source map "sources" field is invalid or missing.'));
+      } else {
+        sourceMap.sources.forEach((x: unknown, i: number) => {
+          if (typeof x !== "string" && x !== null) errors.push(new Error(`There is a source with an invalid format on the index ${i}. Each source should be defined as a string or null`))
+        })
+      }
 
-    if (!("mappings" in sourceMap)) {
-      errors.push(new Error('Source map "mappings" field is missing.'));
-    } else if (typeof sourceMap.mappings !== "string") {
-      errors.push(new Error('Source map "mappings" field is not a string.'));
-    }
+      if (!("mappings" in sourceMap)) {
+        errors.push(new Error('Source map "mappings" field is missing.'));
+      } else if (typeof sourceMap.mappings !== "string") {
+        errors.push(new Error('Source map "mappings" field is not a string.'));
+      }
 
-    if ('sourcesContent' in sourceMap) {
-      if (!Array.isArray(sourceMap.sourcesContent))
-        errors.push(new Error('Source map "sources" field is invalid.'));
-      sourceMap.sourcesContent.forEach((x: unknown, i: number) => {
-        if (x !== null && typeof x !== "string") errors.push(new Error(`There is a source content with an invalid format on the index ${i}. Each content should be defined as a strings or null`))
-      })
+      if ('sourcesContent' in sourceMap) {
+        if (!Array.isArray(sourceMap.sourcesContent))
+          errors.push(new Error('Source map "sources" field is invalid.'));
+        sourceMap.sourcesContent.forEach((x: unknown, i: number) => {
+          if (x !== null && typeof x !== "string") errors.push(new Error(`There is a source content with an invalid format on the index ${i}. Each content should be defined as a strings or null`))
+        })
+      }
     }
 
     return ValidationResult.from(errors);

--- a/src/validators/SourceMapFormatValidator.ts
+++ b/src/validators/SourceMapFormatValidator.ts
@@ -2,54 +2,71 @@ import { Validator } from "../util/Validator.js";
 import { ValidationResult } from "../util/ValidationResult.js";
 import type { ValidationContext } from "../util/ValidationContext.js";
 
+// Defined separately from the validator class below in order to enable easier
+// recursive calls.
+function validateSourceMap(sourceMap : any) : Error[] {
+  const errors: Error[] = [];
+
+  if (sourceMap.version !== 3) {
+    errors.push(new Error(`Source map version is not 3, got ${sourceMap.version}.`));
+  }
+
+  if ("sections" in sourceMap) {
+    if ("mappings" in sourceMap) {
+      errors.push(new Error('Source map cannot have both "mappings" and "sections" fields.'));
+    }
+
+    if (typeof sourceMap.sections !== "object") {
+      errors.push(new Error('Source map "sections" field is not an object.'));
+    } else {
+      sourceMap.sections.forEach((section: any, i: number) => {
+        if (!section.map || !(typeof section.map === "object" && section.map !== null)) {
+          errors.push(new Error(`Index map section ${i} is missing a "map" field or it is invalid.`));
+        } else {
+          // NB: this allows arbitrarily nested index maps, but is that
+          // intended by the spec?
+          const subErrors = validateSourceMap(section.map);
+          errors.push(...subErrors);
+        }
+      });
+    }
+  } else {
+    if (!sourceMap.sources || !Array.isArray(sourceMap.sources)) {
+      errors.push(new Error('Source map "sources" field is invalid or missing.'));
+    } else {
+      sourceMap.sources.forEach((x: unknown, i: number) => {
+        if (typeof x !== "string" && x !== null) errors.push(new Error(`There is a source with an invalid format on the index ${i}. Each source should be defined as a string or null`))
+      })
+    }
+
+    if (!sourceMap.names || !Array.isArray(sourceMap.names)) {
+      errors.push(new Error('Source map "names" field is missing.'));
+    } else {
+      sourceMap.names.forEach((x: unknown, i: number) => {
+        if (typeof x !== "string") errors.push(new Error(`There is a name with an invalid format on the index ${i}. Each name should be defined as a string`))
+      })
+    }
+
+    if (!("mappings" in sourceMap)) {
+      errors.push(new Error('Source map "mappings" field is missing.'));
+    } else if (typeof sourceMap.mappings !== "string") {
+      errors.push(new Error('Source map "mappings" field is not a string.'));
+    }
+
+    if ('sourcesContent' in sourceMap) {
+      if (!Array.isArray(sourceMap.sourcesContent))
+        errors.push(new Error('Source map "sources" field is invalid.'));
+      sourceMap.sourcesContent.forEach((x: unknown, i: number) => {
+        if (x !== null && typeof x !== "string") errors.push(new Error(`There is a source content with an invalid format on the index ${i}. Each content should be defined as a strings or null`))
+      })
+    }
+  }
+
+  return errors;
+}
+
 export class SourceMapFormatValidator extends Validator {
   validate({ sourceMap }: ValidationContext): ValidationResult {
-    const errors: Error[] = [];
-
-    if (sourceMap.version !== 3) {
-      errors.push(new Error("Source map version is not 3."));
-    }
-
-    if ("sections" in sourceMap) {
-      if ("mappings" in sourceMap) {
-        errors.push(new Error('Source map cannot have both "mappings" and "sections" fields.'));
-      }
-
-      if (typeof sourceMap.sections !== "object") {
-        errors.push(new Error('Source map "sections" field is not an object.'));
-      }
-    } else {
-      if (!sourceMap.sources || !Array.isArray(sourceMap.sources)) {
-        errors.push(new Error('Source map "sources" field is invalid or missing.'));
-      } else {
-        sourceMap.sources.forEach((x: unknown, i: number) => {
-          if (typeof x !== "string" && x !== null) errors.push(new Error(`There is a source with an invalid format on the index ${i}. Each source should be defined as a string or null`))
-        })
-      }
-
-      if (!sourceMap.names || !Array.isArray(sourceMap.names)) {
-        errors.push(new Error('Source map "names" field is missing.'));
-      } else {
-        sourceMap.names.forEach((x: unknown, i: number) => {
-          if (typeof x !== "string") errors.push(new Error(`There is a name with an invalid format on the index ${i}. Each name should be defined as a string`))
-        })
-      }
-
-      if (!("mappings" in sourceMap)) {
-        errors.push(new Error('Source map "mappings" field is missing.'));
-      } else if (typeof sourceMap.mappings !== "string") {
-        errors.push(new Error('Source map "mappings" field is not a string.'));
-      }
-
-      if ('sourcesContent' in sourceMap) {
-        if (!Array.isArray(sourceMap.sourcesContent))
-          errors.push(new Error('Source map "sources" field is invalid.'));
-        sourceMap.sourcesContent.forEach((x: unknown, i: number) => {
-          if (x !== null && typeof x !== "string") errors.push(new Error(`There is a source content with an invalid format on the index ${i}. Each content should be defined as a strings or null`))
-        })
-      }
-    }
-
-    return ValidationResult.from(errors);
+    return ValidationResult.from(validateSourceMap(sourceMap));
   }
 }

--- a/src/validators/SourceMapFormatValidator.ts
+++ b/src/validators/SourceMapFormatValidator.ts
@@ -27,6 +27,14 @@ export class SourceMapFormatValidator extends Validator {
         })
       }
 
+      if (!sourceMap.names || !Array.isArray(sourceMap.names)) {
+        errors.push(new Error('Source map "names" field is missing.'));
+      } else {
+        sourceMap.names.forEach((x: unknown, i: number) => {
+          if (typeof x !== "string") errors.push(new Error(`There is a name with an invalid format on the index ${i}. Each name should be defined as a string`))
+        })
+      }
+
       if (!("mappings" in sourceMap)) {
         errors.push(new Error('Source map "mappings" field is missing.'));
       } else if (typeof sourceMap.mappings !== "string") {

--- a/src/validators/SourceMapFormatValidator.ts
+++ b/src/validators/SourceMapFormatValidator.ts
@@ -18,7 +18,7 @@ export class SourceMapFormatValidator extends Validator {
       })
     }
 
-    if (!sourceMap.mappings) {
+    if (!("mappings" in sourceMap)) {
       errors.push(new Error('Source map "mappings" field is missing.'));
     }
 

--- a/src/validators/SourceMapFormatValidator.ts
+++ b/src/validators/SourceMapFormatValidator.ts
@@ -20,6 +20,8 @@ export class SourceMapFormatValidator extends Validator {
 
     if (!("mappings" in sourceMap)) {
       errors.push(new Error('Source map "mappings" field is missing.'));
+    } else if (typeof sourceMap.mappings !== "string") {
+      errors.push(new Error('Source map "mappings" field is not a string.'));
     }
 
     if ('sourcesContent' in sourceMap) {

--- a/src/validators/SourceMapMappingsValidator.ts
+++ b/src/validators/SourceMapMappingsValidator.ts
@@ -8,8 +8,16 @@ import type { ValidationContext } from "../util/ValidationContext.js";
 export class SourceMapMappingsValidator extends Validator {
   async validate({ sourceMap, originalFolderPath, generatedFilePath }: ValidationContext): Promise<ValidationResult> {
     const errors: Error[] = [];
-    const originalFiles = collectSourceFiles(sourceMap, originalFolderPath);
     const generatedFile = TestingFile.fromPathBasedOnFileExtension(generatedFilePath);
+
+    let originalFiles = new Map<string, TestingFile>();
+    if (sourceMap.sections) {
+      for (let section of sourceMap.sections) {
+        const newOriginalFiles = collectSourceFiles(section.map, originalFolderPath);
+        originalFiles = new Map([...originalFiles, ...newOriginalFiles]);
+      }
+    } else
+      originalFiles = collectSourceFiles(sourceMap, originalFolderPath);
 
     try {
       await SourceMapConsumer.with(sourceMap, null, (consumer) => {

--- a/src/validators/SourceMapMappingsValidator.ts
+++ b/src/validators/SourceMapMappingsValidator.ts
@@ -11,27 +11,31 @@ export class SourceMapMappingsValidator extends Validator {
     const originalFiles = collectSourceFiles(sourceMap, originalFolderPath);
     const generatedFile = TestingFile.fromPathBasedOnFileExtension(generatedFilePath);
 
-    await SourceMapConsumer.with(sourceMap, null, (consumer) => {
-      consumer.eachMapping((mapping) => {
-        // Is this a valid situation following the spec?
-        if (mapping.source === null) return
-        const originalFile = originalFiles.get(mapping.source);
+    try {
+      await SourceMapConsumer.with(sourceMap, null, (consumer) => {
+        consumer.eachMapping((mapping) => {
+          // Is this a valid situation following the spec?
+          if (mapping.source === null) return
+          const originalFile = originalFiles.get(mapping.source);
 
-        if (originalFile === undefined) {
-          errors.push(new Error(`There is no content for file with the path "${mapping.source}" on a disk or in the\`sourcesContent\` section`))
-          return
-        }
+          if (originalFile === undefined) {
+            errors.push(new Error(`There is no content for file with the path "${mapping.source}" on a disk or in the\`sourcesContent\` section`))
+            return
+          }
 
-        const notReasonableMappingMessage = this.formatWeirdMappingMessage(mapping, originalFile, generatedFile)
+          const notReasonableMappingMessage = this.formatWeirdMappingMessage(mapping, originalFile, generatedFile)
 
-        if (!originalFile.isMappingReasonable(mapping.originalLine, mapping.originalColumn)) {
-            errors.push(new Error(`${notReasonableMappingMessage} from the original file perspective`))
-        }
-        if (!generatedFile.isMappingReasonable(mapping.generatedLine, mapping.generatedColumn)) {
-          errors.push(new Error(`${notReasonableMappingMessage} from the generated file perspective`))
-        }
+          if (!originalFile.isMappingReasonable(mapping.originalLine, mapping.originalColumn)) {
+              errors.push(new Error(`${notReasonableMappingMessage} from the original file perspective`))
+          }
+          if (!generatedFile.isMappingReasonable(mapping.generatedLine, mapping.generatedColumn)) {
+            errors.push(new Error(`${notReasonableMappingMessage} from the generated file perspective`))
+          }
+        });
       });
-    });
+    } catch (exn : any) {
+      errors.push(new Error(exn.message));
+    }
 
     return ValidationResult.from(errors);
   }


### PR DESCRIPTION
The main part of this PR adds support for index maps to the validator. It assumes a map should be an index map if the `sections` field is present. This requires a few refactorings, such as making it easier to recursively call the validator to check the sub-maps in the sections.

This also updates the source-map package to `0.8.0-beta0`. The reason for that is that `0.7.4` seems to be somewhat buggy for index maps, even though it's a newer release than `0.8.0-beta0`. Ideally we would use a non-beta release with updated code, but it doesn't exist yet. If there's a reason not to upgrade the dependency though, I can defer the index map support and PR the other commits separately.

This includes a few other commits that improve validation that I bundled to avoid having to do history surgery to separate them out, but I could do that if it's preferred (the other commits allow `""` mappings fields, propagate errors from the source maps library, and adds stricter validation for `mappings` and `names`)

I tested this with the source map spec test branch ([here](https://github.com/takikawa/source-map-validator/commit/0c29b5b01d31c65597ee22479721d4e1ba5c0328)). Haven't put this up as a PR yet because not all tests will actually pass due to issues in the source maps library. Maybe the best way to PR it would be to add a notion of "skipped" tests that are known failures?