### PR TITLE
Add new test file for running spec tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+variables:
+  GIT_SUBMODULE_STRATEGY: recursive
+
 on:
   push:
     branches: [ "main" ]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "source-map-tests"]
+	path = source-map-tests
+	url = https://github.com/takikawa/source-map-tests.git

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "tsc --project ./tsconfig.json",
+    "build": "tsc --resolveJsonModule --project ./tsconfig.json",
     "start": "npm run build && node dist/index.js",
     "test": "npm run build && node --test"
   },

--- a/src/spec-tests.test.ts
+++ b/src/spec-tests.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from 'node:url';
+
+import validateSourceMap from "./index.js";
+import sourceMapSpecTests from "../source-map-tests/source-map-spec-tests.json" assert { type: "json" };
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const specResourcesBaseDir = path.resolve(__dirname, "../../source-map-tests/resources");
+
+// These tests are known failures that aren't easily fixed at the moment.
+const skippedTests = [
+  // Source maps library does not consider this a parse error.
+  "invalidMappingSegmentWithZeroFields",
+  // Source maps library ignores the sign bit in the size limit.
+  "invalidMappingSegmentWithColumnExceeding32Bits",
+  // This one has a valid format, but out of range values for the source.
+  "validMappingFieldsWith32BitMaxValues",
+  // Source maps library errors on this.
+  "validMappingLargeVLQ",
+];
+
+test.describe("runSourceMapSpecTests", () => {
+  sourceMapSpecTests.tests.forEach((testCase) => {
+    test(`The source map spec test case "${testCase.name}" has ${testCase.sourceMapIsValid ? "a valid" : "an invalid"} source map`, async (t) => {
+      if (skippedTests.includes(testCase.name)) {
+        t.skip();
+        return;
+      }
+      const result = await validateSourceMap([
+        "--sourceMap",
+        `${specResourcesBaseDir}/${testCase.sourceMapFile}`,
+        "--generatedFile",
+        `${specResourcesBaseDir}/${testCase.baseFile}`,
+        "--originalFolder",
+        `${specResourcesBaseDir}`,
+      ]);
+      if (testCase.sourceMapIsValid)
+        assert.deepEqual(result, { isValid: true }, "expected source map to be valid");
+      else
+        assert.equal(result.isValid, false, "expected source map to be invalid");
+    });
+  });
+});

--- a/src/util/collectSourceFiles.ts
+++ b/src/util/collectSourceFiles.ts
@@ -5,8 +5,11 @@ import type { SourceMap } from "./sourceMap.js";
 export function collectSourceFiles(sourceMap: SourceMap, originalFolderPath: string) {
   const filesMap = new Map<string, TestingFile>();
 
-  sourceMap.sources.forEach((file: string, index: number) => {
-    filesMap.set(file, TestingFile.forTextFile(path.join(originalFolderPath, file), sourceMap.sourcesContent ? sourceMap.sourcesContent[index] : null))
+  sourceMap.sources.forEach((file: string | null, index: number) => {
+    // When the source is null, it might make sense to map to an anonymous source
+    // if a sourceContent is present, but for now just don't add it to the set.
+    if (file !== null)
+      filesMap.set(file, TestingFile.forTextFile(path.join(originalFolderPath, file), sourceMap.sourcesContent ? sourceMap.sourcesContent[index] : null))
   });
 
   return filesMap;

--- a/src/validators/SourceFilesValidator.ts
+++ b/src/validators/SourceFilesValidator.ts
@@ -10,10 +10,10 @@ export class SourceFilesValidator extends Validator {
     const { sources, sourcesContent = [] } = context.sourceMap
 
     function check(sources : any) {
-      sources.forEach((sourceFileName: string, index: number) => {
-        const fullPath = path.join(context.originalFolderPath, sourceFileName);
-        if (!fs.existsSync(fullPath) && sourcesContent[index] == undefined) {
-          errors.push(new Error(`Source file not found: ${sourceFileName}`));
+      sources.forEach((sourceFileName: string | null, index: number) => {
+        const fullPath = sourceFileName === null ? null : path.join(context.originalFolderPath, sourceFileName);
+        if ((!fullPath || !fs.existsSync(fullPath)) && sourcesContent[index] == undefined) {
+          errors.push(new Error(`Source file not found: ${sourceFileName} ${sourcesContent[index]}`));
         }
       });
     };

--- a/src/validators/SourceFilesValidator.ts
+++ b/src/validators/SourceFilesValidator.ts
@@ -12,8 +12,12 @@ export class SourceFilesValidator extends Validator {
     function check(sources : any) {
       sources.forEach((sourceFileName: string | null, index: number) => {
         const fullPath = sourceFileName === null ? null : path.join(context.originalFolderPath, sourceFileName);
-        if ((!fullPath || !fs.existsSync(fullPath)) && sourcesContent[index] == undefined) {
-          errors.push(new Error(`Source file not found: ${sourceFileName} ${sourcesContent[index]}`));
+        // If the path is null, we won't use the source in subsequent passes so
+        // it can be ignored. Otherwise ensure the source makes sense.
+        if (fullPath !== null) {
+          if ((!fullPath || !fs.existsSync(fullPath)) && sourcesContent[index] == undefined) {
+            errors.push(new Error(`Source file not found: ${sourceFileName} ${sourcesContent[index]}`));
+          }
         }
       });
     };

--- a/src/validators/SourceMapFormatValidator.ts
+++ b/src/validators/SourceMapFormatValidator.ts
@@ -55,7 +55,7 @@ function validateSourceMap(sourceMap : any) : Error[] {
 
     if ('sourcesContent' in sourceMap) {
       if (!Array.isArray(sourceMap.sourcesContent))
-        errors.push(new Error('Source map "sources" field is invalid.'));
+        errors.push(new Error('Source map "sourcesContent" field is invalid.'));
       sourceMap.sourcesContent.forEach((x: unknown, i: number) => {
         if (x !== null && typeof x !== "string") errors.push(new Error(`There is a source content with an invalid format on the index ${i}. Each content should be defined as a strings or null`))
       })

--- a/src/validators/SourceMapMappingsValidator.ts
+++ b/src/validators/SourceMapMappingsValidator.ts
@@ -23,7 +23,7 @@ export class SourceMapMappingsValidator extends Validator {
       await SourceMapConsumer.with(sourceMap, null, (consumer) => {
         consumer.eachMapping((mapping) => {
           // Is this a valid situation following the spec?
-          if (mapping.source === null) return
+          if (mapping.source === null || mapping.source === "null") return
           const originalFile = originalFiles.get(mapping.source);
 
           if (originalFile === undefined) {


### PR DESCRIPTION
This PR adds the WIP source map spec tests as a submodule and a new test file to run validity checks for the test cases. It also makes a few (relatively minor) modifications to the validator where needed to make tests pass.